### PR TITLE
Guard init and gate debug logging

### DIFF
--- a/index.html
+++ b/index.html
@@ -1228,10 +1228,23 @@ body.dark-mode-3 #anticipate-fretboard .note.anticipate-guide-tone{
 // ==================================
 
 /**
- * Logs a message to the console with a prefix.
+ * Returns whether debug logging is enabled via URL param or localStorage.
+ * @returns {boolean}
+ */
+function isDebugEnabled() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('debug')) {
+        return params.get('debug') === '1' || params.get('debug') === 'true';
+    }
+    return window.localStorage.getItem('bb-debug') === 'true';
+}
+
+/**
+ * Logs a message to the console with a prefix when debug is enabled.
  * @param {string} message - The message to log.
  */
 function log(message) {
+    if (!isDebugEnabled()) return;
     console.log(`[Bebop Blueprint Debug] ${message}`);
 }
 
@@ -5494,6 +5507,11 @@ if (UI.elements.loopSelectedToggle) {
 // === INITIALIZATION =============
 // ==================================
 async function initializeApp() {
+    if (window.__bbInitialized) {
+        log("initializeApp called more than once; skipping duplicate init.");
+        return;
+    }
+    window.__bbInitialized = true;
     UI.init(); // Cache DOM elements first
     
     // Initial UI setup based on default values
@@ -5595,6 +5613,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function bbSafeInit(){
     try {
       if (typeof window.progressions === 'undefined') return setTimeout(bbSafeInit, 50);
+      if (window.__bbInitialized) return;
       if (typeof window.initializeApp === 'function') window.initializeApp();
     } catch (e) {
       console.error('initializeApp failed:', e);


### PR DESCRIPTION
### Motivation
- Prevent duplicate application initialization that can cause duplicated event listeners, audio re-initialization, and instability during page load.
- Reduce noisy console output in normal operation by only enabling debug logs on demand.
- Provide a simple opt-in mechanism for debugging so developers can turn on logs via query string or persistent setting.

### Description
- Added `isDebugEnabled()` and updated `log()` to only emit when `?debug=1`/`?debug=true` or `localStorage['bb-debug'] === 'true'` is set.
- Added an initialization guard using `window.__bbInitialized` inside `initializeApp()` to skip duplicate inits and an early-return check in the safe bootstrap `bbSafeInit()`.
- Kept existing behavior and comments but made logging and init idempotent to improve runtime smoothness.

### Testing
- No automated tests were run for this change (static HTML/JS edits only).
- Code was committed after local edits and basic static inspection of the modified file was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965736104b48320a422cb261f57e599)